### PR TITLE
requirements: Require slackclient >= 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 slackeventsapi>=2.1.0
-slackclient>=1.1.0
+slackclient>=2.0.0


### PR DESCRIPTION
The 1.y.z series doesn't have a `slack` module, just `slackclient` (e.g. see [here][1]).

[1]: https://github.com/slackapi/python-slackclient/issues/471#issuecomment-507847909