### PR TITLE
hydra: Truncate long error responses

### DIFF
--- a/hydra.py
+++ b/hydra.py
@@ -11,8 +11,11 @@ class RequestException(ValueError):
         self.response = response
 
     def __str__(self):
+        text = self.response.text
+        if len(text) > 160:
+            text = text[:157] + '...'
         return "failed {} -> {}\n{}".format(
-            self.response.url, self.response.status_code, self.response.text
+            self.response.url, self.response.status_code, text,
         )
 
 


### PR DESCRIPTION
Cap the responses at 160 characters (so when we go over we get 157
chars from the response plus a three-char ellipsis).  This keeps us
from spamming Slack if an upstream service hands out a massive HTML
error page.