### PR TITLE
slack api: port from Slack Events API to Slack RTM API

### DIFF
--- a/install.md
+++ b/install.md
@@ -3,25 +3,11 @@
 ```sh
 oc new-app https://github.com/<project>/cluster-support-bot.git \
   -e APP_FILE=cluster-support-bot.py \
-  -e SLACK_SIGNING_SECRET=<credentials from https://api.slack.com/apps/XXXXX/general?> \
+  -e BOT_ID=<bot ID -- hover over the bot name in Slack to get this> \
   -e SLACK_BOT_TOKEN=<token from https://api.slack.com/apps/XXXXXX/install-on-team?> \
   -e HYDRA_USER=<FIXME: how to get one of these> \
   -e HYDRA_PASSWORD=<FIXME: how to get one of these> \
   -e DASHBOARD=https://FIXME.example.com/somewhere-users-can-see-cluster-details?cluster-id=
 ```
 
-```sh
-oc edit route cluster-support-bot
-(add the following to the spec)
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-```
-
-Test by using `oc logs -f <podname>`to make sure it's running.  You can hit it
-with a browser to make sure the route is going through.
-
-Edit https://api.slack.com/apps/XXXXX/event-subscriptions? and update the
-request URL.  The url will be the route of the app + `/slack/events`.  You'll
-wait for a minute or so and it will verify the new URL is working.  Once you
-hit `Save changes` Slack will tell you to "reinstall" the app.
+Test by using `oc logs -f <podname>`to make sure it's running.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-slackeventsapi>=2.1.0
 slackclient>=2.0.0
+requests


### PR DESCRIPTION
Originally we thought RTM would be overkill for this bot.
However, using the Events API requires the bot to be publicly
accessible, and we need it to run internally.

The previous Events implementation used flask from the Slack
library. With RTM there is no longer a server to catch unhandled
Exceptions, so use a global try/catch in `handle_message`
to prevent any unhandled exception from stopping the bot.

There is no `app_mention` event in RTM. Added an env variable
for BOT_USER to reduce the RTM firehose to only messages we
care about, i.e. those @ the bot.