### PR TITLE
cluster-support-bot: Expose subscription managed and support values

### DIFF
--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -180,10 +180,12 @@ def get_summary(cluster):
     ebs_account = telemetry.ebs_account(cluster=cluster)
     summary, related_notes = get_notes(cluster=cluster, ebs_account=ebs_account)
     lines = ['Cluster {}'.format(cluster)]
-    lines.append('Created by Red Hat Customer Portal Account ID {}'.format(ebs_account))
+    lines.extend([
+        'Created by Red Hat Customer Portal Account ID {}'.format(ebs_account),
+        'Dashboard: {}'.format(dashboard_uri(cluster=cluster)),
+    ])
     if summary:
         lines.extend([
-            'Dashboard: {}'.format(dashboard_uri(cluster=cluster)),
             summary['subject'],
             summary['body'],
         ])

--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -177,11 +177,14 @@ def get_notes(cluster, ebs_account):
 
 
 def get_summary(cluster):
-    ebs_account = telemetry.ebs_account(cluster=cluster)
+    subscription = telemetry.subscription(cluster=cluster)
+    ebs_account = telemetry.ebs_account(subscription=subscription)
     summary, related_notes = get_notes(cluster=cluster, ebs_account=ebs_account)
     lines = ['Cluster {}'.format(cluster)]
     lines.extend([
         'Created by Red Hat Customer Portal Account ID {}'.format(ebs_account),
+        'Managed: {}'.format(subscription.get('managed', 'Unknown')),
+        'Support: {}'.format(subscription.get('support', 'None.  Customer Experience and Engagement (CEE) will not be able to open support cases.')),
         'Dashboard: {}'.format(dashboard_uri(cluster=cluster)),
     ])
     if summary:
@@ -206,8 +209,8 @@ def handle_set_summary(payload, args=None, body=None):
     body = (body.strip() + '\n\nThis summary was created by the cluster-support bot.  Workflow docs in https://github.com/openshift/cluster-support-bot/').strip()
     subject_prefix = 'Summary (cluster {}): '.format(cluster)
     try:
-        ebs_account = telemetry.ebs_account(cluster=cluster)
-        summary, related_notes = get_notes(cluster=cluster, ebs_account=ebs_account)
+        ebs_account = telemetry.ebs_account(subscription=telemetry.subscription(cluster=cluster))
+        summary, _ = get_notes(cluster=cluster, ebs_account=ebs_account)
         hydra_client.post_account_note(
             account=ebs_account,
             subject='{}{}'.format(subject_prefix, subject),
@@ -233,7 +236,7 @@ def handle_comment(payload, args=None, body=None):
     except ValueError:  # subject with no body
         subject, body = body, ''
     try:
-        ebs_account = telemetry.ebs_account(cluster=cluster)
+        ebs_account = telemetry.ebs_account(subscription=telemetry.subscription(cluster=cluster))
         hydra_client.post_account_note(
             account=ebs_account,
             subject='cluster {}: {}'.format(cluster, subject),


### PR DESCRIPTION
Builds on #22; review that first.

Internal tooling does not support opening support cases for accounts with
no subscriptions.  Surface that information in the summary display so folks
looking at the cluster will know not to ask CEE to reach out to the
non-customer and request a must-gather or similar.

Also display managed state, because for clusters we manage on the
customer's behalf, we can ask for must-gather and similar internally, and
don't need CEE to pull the customer in.