### PR TITLE
cluster-support-bot: Mention related open cases in the summary

### DIFF
--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -183,6 +183,12 @@ def get_summary(cluster):
         'Support: {}'.format(subscription.get('support', 'None.  Customer Experience and Engagement (CEE) will not be able to open support cases.')),
     ])
     lines.extend('Dashboard: {}{}'.format(dashboard_base, cluster) for dashboard_base in dashboard_bases)
+    cases = [
+        case
+        for case in hydra_client.get_open_cases(account=ebs_account)
+        if cluster in str(hydra_client.get_case_comments(case=case['caseNumber']))
+    ]
+    lines.extend('Case {caseNumber} ({createdDate}, {caseOwner[name]}): {subject}'.format(**case) for case in cases)
     if summary:
         lines.extend([
             summary['subject'],

--- a/hydra.py
+++ b/hydra.py
@@ -80,3 +80,19 @@ class Client(object):
             endpoint="accounts/{}/notes".format(account),
             payload=content,
         )
+
+    def get_open_cases(self, account):
+        return [
+            case
+            for case in (
+                self._hydra(fn=requests.get, endpoint='cases/?accounts={}'.format(account))
+                or []
+            )
+            if not case.get('isClosed')
+        ]
+
+    def get_case_comments(self, case):
+        return (
+            self._hydra(fn=requests.get, endpoint="cases/{}/comments".format(case))
+            or []
+        )


### PR DESCRIPTION
This is a bit slow for accounts with lots of open cases, because we
currently have to hunt through comments on the open cases looking for
the cluster UUID.  Ideally we'll grow a structured way to filter cases
soon, and then we could have a:

```python
hydra.Client().get_open_cases(account=ebs_account, cluster=cluster)
```

that returned related open cases after a single API call.