### PR TITLE
cluster-support-bot: Post private comments to active cases

### DIFF
--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -183,6 +183,12 @@ def get_summary(cluster):
         'Support: {}'.format(subscription.get('support', 'None.  Customer Experience and Engagement (CEE) will not be able to open support cases.')),
     ])
     lines.extend('Dashboard: {}{}'.format(dashboard_base, cluster) for dashboard_base in dashboard_bases)
+    cases = [
+        case
+        for case in hydra_client.get_open_cases(account=ebs_account)
+        if cluster in str(hydra_client.get_case_comments(case=case['caseNumber']))
+    ]
+    lines.extend('Case {caseNumber} ({createdDate}, {caseOwner[name]}): {subject}'.format(**case) for case in cases)
     if summary:
         lines.extend([
             summary['subject'],

--- a/hydra.py
+++ b/hydra.py
@@ -96,3 +96,18 @@ class Client(object):
             self._hydra(fn=requests.get, endpoint="cases/{}/comments".format(case))
             or []
         )
+
+    def put_case_comment(self, case, body, **kwargs):
+        content = {
+            'caseComment': {
+                'caseNumber': case,
+                'commentBody': body,
+            },
+            'additionalData': {},  # without this, Hydra dies with a NullPointerException
+        }
+        content['caseComment'].update(kwargs)
+        return self._hydra(
+            fn=requests.put,
+            endpoint='cases/v2/comments',
+            payload=content,
+        )

--- a/hydra.py
+++ b/hydra.py
@@ -80,3 +80,19 @@ class Client(object):
             endpoint="accounts/{}/notes".format(account),
             payload=content,
         )
+
+    def get_open_cases(self, account):
+        return [
+            case
+            for case in (
+                self._hydra(fn=requests.get, endpoint='cases/?accounts={}'.format(account))
+                or []
+            )
+            if not case.get('isClosed')
+        ]
+
+    def get_case_comments(self, case):
+        return (
+            self._hydra(fn=requests.get, endpoint="cases/{}/comments".format(case))
+            or []
+        )


### PR DESCRIPTION
@rvanderp3 pointed out that case owners are likely to care about these per-cluster comments, but are not necessarily getting notified about new EBS notes.  This commit pushes out duplicate, non-canonical comments to any open cases which mention the cluster in question so that those case owners will be notified.

It's going to be a bit noisy if there are multiple set-summary comments fixing typos and such, because I'm posting new case comments instead of modifying existing ones, but at the moment I expect that to be less problematic than case owners not getting notifications at all.