### PR TITLE
README: 'cluster-support-bot' -> 'cluster-support'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This project is distributed under [the Apache License Version 2.0][LICENSE].
 * go to slack.com and create a new workspace. For example, `< your name >`
 * create your account and set your password
 * go to https://api.slack.com/apps and create a new development app. Name can be something like `< yourname > cluster support`. Choose the workspace you just created.
-* click on the app name and go to Bot Users. Add a development bot, for example, `cluster-support-bot`
+* click on the app name and go to Bot Users. Add a development bot, for example, `cluster-support`
 * click on OAuth & Permissions and install the bot to your workspace
 * copy the Bot User OAuth Access Token and export it to `SLACK_BOT_TOKEN`:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Slack bot for collaboration on per-cluster support issues.
 Ask the bot to explain avialable commands:
 
 ```
-@cluster-support-bot help
+@cluster-support help
 ```
 
 The bot will respond with documentation for the available commands.
@@ -17,7 +17,7 @@ The bot will respond with documentation for the available commands.
 When you notice a problem with a cluster, ask the bot for the current summary:
 
 ```
-@cluster-support-bot summary 09d9436d-52bb-48ba-9026-2ab047158ef6
+@cluster-support summary 09d9436d-52bb-48ba-9026-2ab047158ef6
 ```
 
 The bot will respond with the current cluster summary, if any.
@@ -30,7 +30,7 @@ You can also [get the detailed history](#get-the-detailed-support-history-for-a-
 When the current summary is missing or stale, ask the bot to set a new summary:
 
 ```
-@cluster-support-bot set-summary 09d9436d-52bb-48ba-9026-2ab047158ef6
+@cluster-support set-summary 09d9436d-52bb-48ba-9026-2ab047158ef6
 This is your subject, e.g. Cluster appears to have misconfigured ingress DNS
 This is your body, e.g. The ingress operator has not been configured to manage DNS
 records for *.apps, but it is attempting to resolve them to see whether the user-provided
@@ -54,7 +54,7 @@ You can also [comment on the cluster](#comment-on-a-cluster) without updating th
 When you want more detail than the current summary provides, ask the bot for all the details:
 
 ```
-@cluster-support-bot detail 09d9436d-52bb-48ba-9026-2ab047158ef6
+@cluster-support detail 09d9436d-52bb-48ba-9026-2ab047158ef6
 ```
 
 The bot will respond with the current cluster summary and any comments in reverse-chronological order.
@@ -64,7 +64,7 @@ The bot will respond with the current cluster summary and any comments in revers
 When you want to add a comment about the cluster without updating the summary:
 
 ```
-@cluster-support-bot comment 09d9436d-52bb-48ba-9026-2ab047158ef6
+@cluster-support comment 09d9436d-52bb-48ba-9026-2ab047158ef6
 This is your subject, e.g. Opened support case about the missing *.apps DNS records
 This is your body, e.g. Case https://example.com/123  Customer says they may be
 able to dig into this tomorrow.


### PR DESCRIPTION
Slack marks the account as an app, so we don't need to be explicit about that in our name.