### PR TITLE
cluster-support-bot: Add entitlements

### DIFF
--- a/hydra.py
+++ b/hydra.py
@@ -81,6 +81,12 @@ class Client(object):
             payload=content,
         )
 
+    def get_entitlements(self, account):
+        return (
+            self._hydra(fn=requests.get, endpoint="/entitlements/account/{}".format(account))
+            or []
+        )
+
     def get_open_cases(self, account):
         return [
             case


### PR DESCRIPTION
Refining 921f703ff5 (#23).  Customers can purchase entitlements, but subscription [is][1] [manual][2].  CEE cannot open cases unless the customer has *some* entitlements, but they do not require the particular cluster to be entitled.  When they have other entitlements, support is possible.  But support for unsubscribed clusters is us reaching out to help customers when they are not paying us to support that cluster, so we will probably only do it when we are interested in the cluster for our own purposes (e.g. root-causing a new bug) and not for healing that particular cluster (e.g. if it hit an already-understood bug).

[1]: https://docs.openshift.com/container-platform/4.2/architecture/architecture.html#cluster-entitlements_architecture
[2]: https://cloud.redhat.com/openshift/register