### PR TITLE
telemetry: use `max_over_time` to ensure we don't tune offset anymore

### DIFF
--- a/telemetry.py
+++ b/telemetry.py
@@ -47,7 +47,7 @@ def _query(query):
 def subscription(cluster):
     """Get the cluster's subscription_labels.
     """
-    data = _query(query='topk(1, subscription_labels{{_id="{}"}} offset 3h)'.format(cluster))
+    data = _query(query='topk(1, max_over_time(subscription_labels{{_id="{}",support!=""}}[1w]))'.format(cluster))
     if not data.get('data', {}).get('result'):
         raise ValueError('no subscription labels found')
 


### PR DESCRIPTION
Observatorium delays may increase, seems `max_over_time` does the same trick but won't have to tuned every time. `1w` has been picked to handle outages too