### PR TITLE
hydra: use 365 days as a substitute for years

### DIFF
--- a/hydra.py
+++ b/hydra.py
@@ -6,7 +6,7 @@ requests.packages.urllib3.disable_warnings()
 __version__ = "0.1.0"
 
 defaultExpiryPeriod = {
-    'year': 1
+    'days': 365
 }
 
 class Client(object):


### PR DESCRIPTION

Python's timedelta doesn't have "year" param, so use 365 days instead