### PR TITLE
hydra: ISO-8601 / RFC-3339 format for expiryDate

### DIFF
--- a/hydra.py
+++ b/hydra.py
@@ -70,7 +70,7 @@ class Client(object):
                 # We likely will want to use "General Info" for most notes, but possibly use "Key Notes" for summaries
                 "type": noteType,
                 "subject": subject,
-                "expiryDate": expiryDate,
+                "expiryDate": expiryDate.isoformat(),
             }
         }
         if intendedReviewDate:


### PR DESCRIPTION
Avoid:

```
DEBUG:__main__:uncaught Exception in handle_message: Object of type 'date' is not JSON serializable
```

Docs for this property are not great, but internal discussion shows that values like `2020-09-09T14:00:00.000Z` will work.  That looks like [`iso-date-time` with an explicit `time-zone`][1].  Not clear to me if RFC 3339's `date` form will work or not.  I guess we'll see ;).

[1]: https://tools.ietf.org/html/rfc3339#page-13