### PR TITLE
bot: rework handle_message to use asyncio

### DIFF
--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -70,20 +70,17 @@ async def _handle_message(msg_id, payload):
     # https://api.slack.com/events/message#message_subtypes
     msg_subtype = payload['data'].get('subtype')
     if msg_subtype is not None:
-        logger.debug("msg id {}: invalid subtype '{}'".format(msg_id, msg_subtype))
         return
 
     text = payload['data'].get('text')
     if not text:
-        logger.debug("msg id {}: empty text".format(msg_id))
         return
-
-    logger.debug("msg id {}: parsing '{}'".format(msg_id, text))
 
     handle_uuid_mention(text)
     if not text.startswith(bot_mention):
-        logger.debug("msg id {}: not prefixed with bot ID".format(msg_id))
         return
+
+    logger.debug("msg id {}: parsing '{}'".format(msg_id, text))
 
     user_arg_line, body = (text.strip()+'\n').split('\n', 1)
     user_args = user_arg_line.split()[1:]  # split and drop the '<@{bot-id}>' prefix

--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -1,3 +1,4 @@
+import asyncio
 import argparse
 import logging
 import os
@@ -53,36 +54,34 @@ class ErrorRaisingArgumentParser(argparse.ArgumentParser):
 @slack.RTMClient.run_on(event='message')
 def handle_message(**payload):
     try:
-        _handle_message(payload=payload)
+        # Throw exception if the message doesn't have ID
+        message_id = payload['data']['client_msg_id']
+        logger.debug("Received message id {}:\n{}".format(message_id, payload))
+        asyncio.ensure_future(
+            _handle_message(msg_id=message_id, payload=payload),
+            loop=asyncio.get_event_loop())
     except Exception as e:
         logger.debug('uncaught Exception in handle_message: {}'.format(e))
 
 
-def _handle_message(payload):
-    global recent_events
+async def _handle_message(msg_id, payload):
+    # https://api.slack.com/events/message#message_subtypes
+    msg_subtype = payload['data'].get('subtype')
+    if msg_subtype is not None:
+        logger.debug("msg id {}: invalid subtype '{}'".format(msg_id, msg_subtype))
+        return
 
-    data = payload.get('data')
-    if not data:
-        return
-    if data.get('subtype') is not None:
-        return  # https://api.slack.com/events/message#message_subtypes
-    text = data.get('text')
+    text = payload['data'].get('text')
     if not text:
+        logger.debug("msg id {}: empty text".format(msg_id))
         return
+
+    logger.debug("msg id {}: parsing '{}'".format(msg_id, text))
+
     handle_uuid_mention(text)
     if not text.startswith(bot_mention):
+        logger.debug("msg id {}: not prefixed with bot ID".format(msg_id))
         return
-
-    logger.debug('handle_message: {}'.format(payload))
-
-    timestamp = float(data.get('ts', 0))
-    if timestamp in recent_events:  # high-resolution timestamps should have few false-negatives
-        logger.info('ignoring duplicate message: {}'.format(message))
-        return
-
-    recent_events.add(timestamp)  # add after check without a lock should be a small race window
-    cutoff = time.time() - 60*60  # keep events for an hour
-    recent_events = {timestamp for timestamp in recent_events if timestamp > cutoff}
 
     user_arg_line, body = (text.strip()+'\n').split('\n', 1)
     user_args = user_arg_line.split()[1:]  # split and drop the '<@{bot-id}>' prefix

--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -54,8 +54,10 @@ class ErrorRaisingArgumentParser(argparse.ArgumentParser):
 @slack.RTMClient.run_on(event='message')
 def handle_message(**payload):
     try:
-        # Throw exception if the message doesn't have ID
-        message_id = payload['data']['client_msg_id']
+        # Exit if the message doesn't have ID
+        message_id = payload['data'].get('client_msg_id')
+        if not message_id:
+            return
         logger.debug("Received message id {}:\n{}".format(message_id, payload))
         asyncio.ensure_future(
             _handle_message(msg_id=message_id, payload=payload),

--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -97,6 +97,7 @@ async def _handle_message(msg_id, payload):
         if not handler:
             logger.info('no handler found for {!r}'.format(user_args))
             return
+        logger.info('msg id {}: running handler {}'.format(msg_id, handler.__name__))
         response = handler(payload=payload, args=args, body=body)
         if not response:
             return

--- a/telemetry.py
+++ b/telemetry.py
@@ -31,6 +31,7 @@ def _query(query):
             'Authorization': 'Bearer {}'.format(TOKEN),
             'User-Agent': 'cluster-support-bot/{}'.format(__version__),
         },
+        timeout=60,
         **_ADDITIONAL_REQUEST_ARGUMENTS,
     )
 


### PR DESCRIPTION
Slack API handler is not really async (see https://github.com/slackapi/python-slackclient/issues/558). This commit ensures messages are parsed async, so that other requests were not ignored.

* rework functions as async and run them as a part of async loop
* update logging
* remove duplicate message check - this required `global` var and
  apparently has been a slackclient bug
* normalize received text - convert from unicode to plain text, so that non-breakable spaces would become spaces before parsing
* limit request timeouts to 1 minute