### PR TITLE
telemetry: 'topk' -> 'group', and drop subscription range to 60h

### DIFF
--- a/cluster-support-bot.py
+++ b/cluster-support-bot.py
@@ -240,7 +240,7 @@ def get_entitlements_summary(ebs_account):
 
 
 def get_summary(cluster):
-    subscription = telemetry.subscription(cluster=cluster)
+    subscription = telemetry.subscription(cluster=cluster, labels={'ebs_account', 'managed', 'support'})
     ebs_account = telemetry.ebs_account(subscription=subscription)
     summary, related_notes = get_notes(cluster=cluster, ebs_account=ebs_account)
     lines = ['Cluster {}'.format(cluster)]
@@ -279,7 +279,7 @@ def handle_set_summary(payload, args=None, body=None):
     body = (body.strip() + '\n\nThis summary was created by the cluster-support bot.  Workflow docs in https://github.com/openshift/cluster-support-bot/').strip()
     subject_prefix = 'Summary (cluster {}): '.format(cluster)
     try:
-        ebs_account = telemetry.ebs_account(subscription=telemetry.subscription(cluster=cluster))
+        ebs_account = telemetry.ebs_account(subscription=telemetry.subscription(cluster=cluster, labels={'ebs_account'}))
         summary, _ = get_notes(cluster=cluster, ebs_account=ebs_account)
         hydra_client.post_account_note(
             account=ebs_account,
@@ -307,7 +307,7 @@ def handle_comment(payload, args=None, body=None):
     except ValueError:  # subject with no body
         subject, body = body, ''
     try:
-        ebs_account = telemetry.ebs_account(subscription=telemetry.subscription(cluster=cluster))
+        ebs_account = telemetry.ebs_account(subscription=telemetry.subscription(cluster=cluster, labels={'ebs_account'}))
         hydra_client.post_account_note(
             account=ebs_account,
             subject='cluster {}: {}'.format(cluster, subject),

--- a/telemetry.py
+++ b/telemetry.py
@@ -44,10 +44,11 @@ def _query(query):
     return data
 
 
-def subscription(cluster):
+def subscription(cluster, labels=None):
     """Get the cluster's subscription_labels.
     """
-    data = _query(query='topk(1, max_over_time(subscription_labels{{_id="{}",support!=""}}[1w]))'.format(cluster))
+    data = _query(query='group by ({}) (max_over_time(subscription_labels{{_id="{}",support!=""}}[60h]))'.format(','.join(sorted(labels)), cluster))
+
     if not data.get('data', {}).get('result'):
         raise ValueError('no subscription labels found')
 


### PR DESCRIPTION
`group` is more efficient, especially when we list the labels we're looking for, because it can stop after it finds a single matching entry instead of iterating through all the matching entries.  Although if it needs to iterate through all the entries looking for possibly different match groups, I dunno if that helps all that much.  Still, unlikely to be less efficient.

Dropping the time range from a week to 60h should avoid errors we've been seeing recently like:

    receive series from Addr: ...[name:"ruler_replica" value:"thanos-ruler-1" ] Mint: 1562803200000 Maxt: 1607630400000: rpc error: code = Aborted desc = fetch series for block 01ERQRVX3WQNWDFM24Z6SNF77E: expanded matching posting: get postings: read postings range: get range reader: The specified key does not exist.

I don't understand what's going on there, but time ranges of 63h and larger seem to fail that way, while ranges of 62h and shorter succeed.  60 is a nice, round multiple of 12 that succeeds at the moment.